### PR TITLE
Bitbucket issue tracking for index suggestions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ source "https://rubygems.org"
 #
 # This will help ensure the proper Jekyll version is running.
 # Happy Jekylling!
-gem "jekyll", "~> 3.8.5"
+gem "jekyll", "~> 3.8.6"
 gem "html-proofer"
 
 # This is the default theme for new Jekyll sites. You may change this to anything you like.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,7 +32,7 @@ GEM
     http_parser.rb (0.6.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
-    jekyll (3.8.5)
+    jekyll (3.8.6)
       addressable (~> 2.4)
       colorator (~> 1.0)
       em-websocket (~> 0.5)

--- a/bitbucket_issue_tracker.py
+++ b/bitbucket_issue_tracker.py
@@ -12,8 +12,9 @@ parser.add_argument('--sort_by_updated', default=False, action='store_true', hel
 parser.add_argument('--num_pages', default=1, help="Number of pages for which results will be showed. (Each page shows 25 results)")
 args = parser.parse_args()
 
+rake = Rake(min_length = args.min_keyw_length, max_length= args.max_keyw_length, ranking_metric=Metric.WORD_DEGREE)
+
 for page in range(int(args.num_pages)):
-    rake = Rake(min_length = args.min_keyw_length, max_length= args.max_keyw_length, ranking_metric=Metric.WORD_DEGREE)
     if not args.sort_by_updated:
         r = requests.get(url = "https://api.bitbucket.org/2.0/repositories/osrf/gazebo/issues?sort=-votes&page=" + str(page+1)) 
     else:

--- a/bitbucket_issue_tracker.py
+++ b/bitbucket_issue_tracker.py
@@ -1,0 +1,61 @@
+from rake_nltk import Rake, Metric
+import argparse
+import requests 
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--only_title', default=False, action='store_true', help="For extracting keywords only from title of the Bitbucket issue.")
+parser.add_argument('--with_comments', default=False, action='store_true', help="For extracting keywords from the title, content (body) and comments of the Bitbucket issue.")
+parser.add_argument('--min_score', default=4, help="Minimum required score of an extracted keyword.")
+parser.add_argument('--min_keyw_length', default=1, help="Minimum length of an extracted keyword phrase.")
+parser.add_argument('--max_keyw_length', default=4, help="Maximum length of an extracted keyword phrase.")
+parser.add_argument('--sort_by_updated', default=False, action='store_true', help="To sort issues based on updation date")
+parser.add_argument('--num_pages', default=1, help="Number of pages for which results will be showed. (Each page shows 25 results)")
+args = parser.parse_args()
+
+for page in range(int(args.num_pages)):
+    rake = Rake(min_length = args.min_keyw_length, max_length= args.max_keyw_length, ranking_metric=Metric.WORD_DEGREE)
+    if not args.sort_by_updated:
+        r = requests.get(url = "https://api.bitbucket.org/2.0/repositories/osrf/gazebo/issues?sort=-votes&page=" + str(page+1)) 
+    else:
+        r = requests.get(url = "https://api.bitbucket.org/2.0/repositories/osrf/gazebo/issues&page=" + str(page+1)) 
+        
+    data = r.json()
+    for i,j in enumerate(data['values']):
+        print ("Issue title: " + str(page * 20 + i + 1) + ': ' + j['title'])
+        print ('Votes: ' + str(j['votes']))
+        if args.only_title:
+            rake.extract_keywords_from_text(j['title'])
+            keyw_title = rake.get_ranked_phrases_with_scores()
+            print(keyw_title)
+        
+        elif args.with_comments:
+            rq = requests.get(url = j['links']['comments']['href'])
+            output = rq.json()
+            comments = ''
+            
+            rake.extract_keywords_from_text(j['title'] + " " + j['content']['raw'])
+            keyw_title_content = rake.get_ranked_phrases_with_scores()
+            top_keyw_title_content = [a for a in keyw_title_content if a[0] >= args.min_score]
+
+            print("Keywords from title and content: ")
+            print(top_keyw_title_content)
+            
+            for k in output['values']:
+                comments += str(k['content']['raw'])
+            
+            rake.extract_keywords_from_text(comments)
+            keyw_comments = rake.get_ranked_phrases_with_scores()
+            top_keyw_comments = [a for a in keyw_comments if a[0]>= args.min_score]
+            
+            print("Keywords from comments")
+            print(top_keyw_comments)
+        else:
+            rake.extract_keywords_from_text(j['title'] + " " + j['content']['raw'])
+            keyw_title_content = rake.get_ranked_phrases_with_scores()
+            top_keyw_title_content = [a for a in keyw_title_content if a[0] >= args.min_score]
+
+            print("Keywords from title and content: ")
+            if (len(top_keyw_title_content) > 0):
+                print(list(zip(*top_keyw_title_content))[1])
+
+        print('------------------------------------------------------------')

--- a/gazebo_answers_tracker.py
+++ b/gazebo_answers_tracker.py
@@ -6,37 +6,75 @@ import argparse
 parser = argparse.ArgumentParser()
 parser.add_argument('--min_keyw_length', default=1, help="Minimum length of an extracted keyword phrase.")
 parser.add_argument('--max_keyw_length', default=4, help="Maximum length of an extracted keyword phrase.")
+parser.add_argument('--min_score', default=4, help="Minimum required score of an extracted keyword.")
+parser.add_argument('--print_content', default=False, action='store_true', help="To print content of question and answers")
+parser.add_argument('--num_pages', default=1, help="Number of pages for which results will be showed. (Each page shows 30 results)")
+
+class bcolors:
+    HEADER = '\033[95m'
+    OKBLUE = '\033[94m'
+    OKGREEN = '\033[92m'
+    WARNING = '\033[93m'
+    FAIL = '\033[91m'
+    ENDC = '\033[0m'
+    BOLD = '\033[1m'
+    UNDERLINE = '\033[4m'
+
 args = parser.parse_args()
-
-page = requests.get('http://answers.gazebosim.org/questions/scope:all/sort:votes-desc/page:1/')
-soup = BeautifulSoup(page.text, 'html.parser')
-question_list = soup.find(id='question-list')
-
 rake = Rake(min_length = args.min_keyw_length, max_length= args.max_keyw_length, ranking_metric=Metric.WORD_DEGREE)
-for question in question_list(recursive=False):
 
-    id = question.get('id')[9:]
-    question_title = (question.find('h2').find('a').text)
-    rake.extract_keywords_from_text(question_title)
-    keyw_q_title = rake.get_ranked_phrases_with_scores()
+for page in range(int(args.num_pages)):
+    req = requests.get('http://answers.gazebosim.org/questions/scope:all/sort:votes-desc/page:'+ str(page+1) + '/')
 
-    print(question_title)
-    print(keyw_q_title)
-    # scraping RSS feed of question
+    if not req.ok:
+        raise Exception(bcolors.FAIL + "Request returned " + str(req.status_code) + " error." + bcolors.ENDC)
 
-    rss = requests.get('http://answers.gazebosim.org/feeds/question/' + id)
-    soup_rss = BeautifulSoup(rss.text, "xml")
+    soup = BeautifulSoup(req.text, 'html.parser')
+    question_list = soup.find(id='question-list')
 
-    items = soup_rss.findAll("item")
+    print('Page ' + str(page+1))
+    for indx, question in enumerate(question_list(recursive=False)):
 
-    for item in items:
-        if (item.title.text[:7] != 'Comment'):
-            print('Answer is: ')
-            print(item.description.text)
-            rake.extract_keywords_from_text(item.description.text)
-            # keyw_q_answer = rake.get_ranked_phrases_with_scores()
-            keyw_q_answer = rake.get_ranked_phrases()
-            print('Keywords of answer are: ')
-            print(keyw_q_answer)
-    
-    break
+        id = question.get('id')[9:]
+        question_title = (question.find('h2').find('a').text)
+        rake.extract_keywords_from_text(question_title)
+        
+        keyw_q_title = rake.get_ranked_phrases_with_scores()
+        top_keyw_q_title = [a for a in keyw_q_title if a[0] >= args.min_score]
+        
+        print("\n" + bcolors.BOLD + 'Question #' + str(page * 30 + indx + 1) + bcolors.ENDC)
+        if (args.print_content):
+            print("Question title: " + bcolors.HEADER + question_title + bcolors.ENDC)
+        
+        print('Keywords of question title are: ', end=" ")
+        
+        print(bcolors.BOLD, end="") # bold for easy visibility
+        if (len(top_keyw_q_title) > 0):
+            print(list(zip(*top_keyw_q_title))[1])
+        print(bcolors.ENDC)
+
+        # scraping RSS feed of question
+
+        rss = requests.get('http://answers.gazebosim.org/feeds/question/' + id)
+        soup_rss = BeautifulSoup(rss.text, "xml")
+
+        items = soup_rss.findAll("item")
+
+        ind = 0
+        for item in items:
+            if (item.title.text[:7] != 'Comment'):
+                ind += 1
+                if (args.print_content):
+                    print('Answer is: ')
+                    print(bcolors.HEADER + item.description.text + bcolors.ENDC)
+                rake.extract_keywords_from_text(item.description.text)
+                keyw_q_answer = rake.get_ranked_phrases_with_scores()
+                top_keyw_q_answer = [a for a in keyw_q_answer if a[0] >= args.min_score]
+
+                print('Keywords of answer ' + str(ind) + ' are: ')
+                if (len(top_keyw_q_answer) > 0):
+                    print(bcolors.BOLD)
+                    print(list(zip(*top_keyw_q_answer))[1])
+                    print(bcolors.ENDC)
+
+        print('----------------------------------------------------------------------------')

--- a/gazebo_answers_tracker.py
+++ b/gazebo_answers_tracker.py
@@ -7,6 +7,8 @@ parser = argparse.ArgumentParser()
 parser.add_argument('--min_keyw_length', default=1, help="Minimum length of an extracted keyword phrase.")
 parser.add_argument('--max_keyw_length', default=4, help="Maximum length of an extracted keyword phrase.")
 parser.add_argument('--min_score', default=4, help="Minimum required score of an extracted keyword.")
+parser.add_argument('--default_sort', default=False, action='store_true', help="To sort issues based on post activity")
+parser.add_argument('--answers_sort', default=False, action='store_true', help="To sort issues based on most answered")
 parser.add_argument('--print_content', default=False, action='store_true', help="To print content of question and answers")
 parser.add_argument('--num_pages', default=1, help="Number of pages for which results will be showed. (Each page shows 30 results)")
 
@@ -24,7 +26,15 @@ args = parser.parse_args()
 rake = Rake(min_length = args.min_keyw_length, max_length= args.max_keyw_length, ranking_metric=Metric.WORD_DEGREE)
 
 for page in range(int(args.num_pages)):
-    req = requests.get('http://answers.gazebosim.org/questions/scope:all/sort:votes-desc/page:'+ str(page+1) + '/')
+    if not args.default_sort and not args.answers_sort:
+        req = requests.get('http://answers.gazebosim.org/questions/scope:all/sort:votes-desc/page:'+ str(page+1) + '/')
+        print("Entries sorted based on votes: ")
+    elif args.answers_sort:
+        print("Entries sorted based on most-answered: ")
+        req = requests.get('http://answers.gazebosim.org/questions/scope:all/sort:answers-desc/page:'+ str(page+1) + '/')
+    elif args.default_sort:
+        print("Entries sorted based on activity: ")
+        req = requests.get('http://answers.gazebosim.org/questions/scope:all/sort:activity-desc/page:'+ str(page+1) + '/')
 
     if not req.ok:
         raise Exception(bcolors.FAIL + "Request returned " + str(req.status_code) + " error." + bcolors.ENDC)

--- a/gazebo_answers_tracker.py
+++ b/gazebo_answers_tracker.py
@@ -1,0 +1,42 @@
+import requests
+from bs4 import BeautifulSoup
+from rake_nltk import Rake, Metric
+import argparse
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--min_keyw_length', default=1, help="Minimum length of an extracted keyword phrase.")
+parser.add_argument('--max_keyw_length', default=4, help="Maximum length of an extracted keyword phrase.")
+args = parser.parse_args()
+
+page = requests.get('http://answers.gazebosim.org/questions/scope:all/sort:votes-desc/page:1/')
+soup = BeautifulSoup(page.text, 'html.parser')
+question_list = soup.find(id='question-list')
+
+rake = Rake(min_length = args.min_keyw_length, max_length= args.max_keyw_length, ranking_metric=Metric.WORD_DEGREE)
+for question in question_list(recursive=False):
+
+    id = question.get('id')[9:]
+    question_title = (question.find('h2').find('a').text)
+    rake.extract_keywords_from_text(question_title)
+    keyw_q_title = rake.get_ranked_phrases_with_scores()
+
+    print(question_title)
+    print(keyw_q_title)
+    # scraping RSS feed of question
+
+    rss = requests.get('http://answers.gazebosim.org/feeds/question/' + id)
+    soup_rss = BeautifulSoup(rss.text, "xml")
+
+    items = soup_rss.findAll("item")
+
+    for item in items:
+        if (item.title.text[:7] != 'Comment'):
+            print('Answer is: ')
+            print(item.description.text)
+            rake.extract_keywords_from_text(item.description.text)
+            # keyw_q_answer = rake.get_ranked_phrases_with_scores()
+            keyw_q_answer = rake.get_ranked_phrases()
+            print('Keywords of answer are: ')
+            print(keyw_q_answer)
+    
+    break

--- a/gazebo_answers_tracker.py
+++ b/gazebo_answers_tracker.py
@@ -51,6 +51,9 @@ for page in range(int(args.num_pages)):
         print(bcolors.BOLD, end="") # bold for easy visibility
         if (len(top_keyw_q_title) > 0):
             print(list(zip(*top_keyw_q_title))[1])
+        else:
+            print("None")
+            print(bcolors.ENDC + "Question title: " + bcolors.BOLD + question_title + bcolors.ENDC)
         print(bcolors.ENDC)
 
         # scraping RSS feed of question
@@ -72,9 +75,13 @@ for page in range(int(args.num_pages)):
                 top_keyw_q_answer = [a for a in keyw_q_answer if a[0] >= args.min_score]
 
                 print('Keywords of answer ' + str(ind) + ' are: ')
+                print(bcolors.BOLD)
                 if (len(top_keyw_q_answer) > 0):
-                    print(bcolors.BOLD)
                     print(list(zip(*top_keyw_q_answer))[1])
-                    print(bcolors.ENDC)
+                else:
+                    print("None")
+                    print(bcolors.ENDC + "Answer content: " + bcolors.BOLD + item.description.text + bcolors.ENDC)
+
+                print(bcolors.ENDC)
 
         print('----------------------------------------------------------------------------')


### PR DESCRIPTION
For getting ideas about new items that can be added to the documentation index, I have added a Python script that scrapes the [Gazebo repository issues](https://bitbucket.org/osrf/gazebo/issues?status=new&status=open) using Bitbucket's API and extracts important keywords from the issue's title, content and/or the comments. 

By default the results are sorted based on the vote-count of the issue, but by using the ```--sort_by_updated``` parameter issues can be sorted based on the order of updation. More control can be performed on the results by using the other parameters, based on the requirements. 

#### Pre-requisites:
``` 
pip3 install rake_nltk
python -c "import nltk; nltk.download('stopwords')"
```
#### How to run:
```
python3 bitbucket_issue_tracker.py
``` 

Example result -> 

![Screenshot 2019-07-06 at 10 52 49 PM](https://user-images.githubusercontent.com/24846546/60759323-fc22c900-a040-11e9-84f7-4da71bf27c3f.png)

Next, need to work on linking index entries to these results.