### PR TITLE
Fixed CSS code for Mozilla Firefox browser

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -12,8 +12,8 @@ layout: "wrapper"
     <div class="row">
         <ol class="cat-ol" start="0">
             {% for cat in site.categories %}
-                <div class="col-xs-11 col-md-4" style="min-height: 160px">
-                    <li><a style="text-decoration: none" href="{{cat.url | prepend: site.baseurl}}"><h3 class="cat-title">{{cat.title}}</h3></a></li>
+                <div class="col-xs-11 col-md-4 cat-card">
+                    <li><a style="text-decoration: none" href="{{cat.url | prepend: site.baseurl}}"><span class="cat-title">{{cat.title}}</span></a></li>
                     <p class="cat-desc">{{cat.desc}}</p>
                 </div>
             {% endfor %}

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -93,6 +93,10 @@ h1 {
   font-weight: 300;
 }
 
+.cat-ol {
+  margin-top: 20px;
+}
+
 .cat-ol li{
   color: #428bca;
   font-size: 24px;
@@ -102,6 +106,14 @@ h1 {
 .cat-title {
   color: #428bca;
   font-weight: 300;
+}
+
+.cat-card {
+  min-height: 160px;
+}
+
+.cat-desc {
+  margin-top: 12px;
 }
 
 .item-title {


### PR DESCRIPTION
This commit fixes an issue with the website's view on Mozilla's Firefox browser.

**Before:**

![image](https://user-images.githubusercontent.com/24846546/61480495-ba384200-a9b3-11e9-8ba8-2f765e5c4a7d.png)

**After:**

![image](https://user-images.githubusercontent.com/24846546/61480650-0a170900-a9b4-11e9-94a5-f68bbe3c9d83.png)

 